### PR TITLE
Fix shader for gles; Fix mouse speed

### DIFF
--- a/game/conf.lua
+++ b/game/conf.lua
@@ -1,10 +1,11 @@
 function love.conf(t)
-	t.window.width = 1024
-	t.window.height = 512
+	t.window.width = 0
+	t.window.height = 0
 	t.window.resizable = false
 	t.window.title = "Going Home: Revisited"
 	t.window.icon = "assets/icon.png"
 	t.window.fullscreen = true
+	t.window.fullscreentype = "exclusive"
 
 	t.version = "11.5"
 	t.identity = "GoingHomeRevisited"

--- a/game/gameStates.lua
+++ b/game/gameStates.lua
@@ -294,9 +294,9 @@ end
 function gamestates.getState() return STATES end
 
 function gamestates.update(dt)
-	local mx, my = love.mouse.getPosition()
-	mx = mx / RATIO
-	my = (my + TY) / RATIO
+	local mx, my = MOUSE_X, MOUSE_Y
+	mx = mx / RATIO_X
+	my = my / RATIO_Y
 
 	if currentRoom == IMAGES["leftRoom"] or
 		currentRoom == IMAGES["rightRoom"] or

--- a/game/main.lua
+++ b/game/main.lua
@@ -31,8 +31,8 @@ love.graphics.setDefaultFilter("nearest", "nearest", 1)
 local img_loading = love.graphics.newImage("assets/loading.png")
 local lsw, lsh = img_loading:getDimensions()
 
-local cursor = love.mouse.newCursor("assets/cursor.png")
-love.mouse.setCursor(cursor)
+cursorImage = love.graphics.newImage("assets/cursor.png")
+love.mouse.setVisible(false)
 
 local URLS = require("urls")
 local Shaders = require("shaders")
@@ -76,7 +76,8 @@ MAIN_CANVAS = love.graphics.newCanvas(love.graphics.getDimensions())
 local function toggle_fs()
 	love.window.setFullscreen(not love.window.getFullscreen())
 	local g_width, g_height = love.graphics.getDimensions()
-	RATIO = math.min(g_width / WIDTH, g_height / HEIGHT)
+	RATIO_X, RATIO_Y = g_width / WIDTH, g_height / HEIGHT
+	RATIO = math.min(RATIO_X, RATIO_Y)
 	MAIN_CANVAS = love.graphics.newCanvas(love.graphics.getDimensions())
 end
 
@@ -171,7 +172,8 @@ function love.load()
 	CLOCK = 0 --game timer
 
 	local g_width, g_height = love.graphics.getDimensions()
-	RATIO = math.min(g_width / WIDTH, g_height / HEIGHT)
+	RATIO_X, RATIO_Y = g_width / WIDTH, g_height / HEIGHT
+	RATIO = math.min(RATIO_X, RATIO_Y)
 	PRESSED = false
 	love.keyboard.setKeyRepeat(true)
 
@@ -212,6 +214,8 @@ function love.load()
 end
 
 function love.update(dt)
+	MOUSE_X, MOUSE_Y = love.mouse.getPosition()
+
 	-- if recording then return end
 	CLOCK = CLOCK + dt
 
@@ -243,7 +247,7 @@ function love.update(dt)
 				if SaveData.data.hide_cursor then
 					love.mouse.setVisible(false)
 				else
-					love.mouse.setVisible(true)
+					love.mouse.setVisible(false)
 				end
 			end
 
@@ -312,6 +316,7 @@ function love.draw()
 	end
 	love.graphics.draw(MAIN_CANVAS, TX, TY)
 	love.graphics.setShader()
+    love.graphics.draw(cursorImage, MOUSE_X, MOUSE_Y)
 
 	-- love.graphics.setColor(1, 0, 0, 1)
 	-- local ry = love.graphics.getHeight()/2 - (HEIGHT*RATIO)/2

--- a/game/shaders/palette_swap.glsl
+++ b/game/shaders/palette_swap.glsl
@@ -4,7 +4,7 @@ vec4 effect( vec4 color, Image tex, vec2 texture_coords, vec2 screen_coords )
 {
     vec4 index = Texel(tex, texture_coords);
 
-    if (index.a == 0)
+    if (index.a == 0.0)
       discard;
 
     vec4 pixel = Texel(u_tex_palette, vec2(index.x, 1));


### PR DESCRIPTION
The changes was made for the port for devices with only embedded support, but I realized it can be useful.
It addresses:
- incompatibility of shader with GLES (it doesn't allows implicit conversion)
- invisible mouse where hardware is not available (changed to software cursor)
- scaling for different resolutions
- fixed speed of mouse cursor because of scaling